### PR TITLE
Add Beton Inspector (open-source 6sense / Clearbit alternative)

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -21955,7 +21955,7 @@
       "Scores and routes leads from real product-usage signals (PostHog) + CRM",
       "Self-hostable via Docker, billing optional",
       "Modern stack: TypeScript, Next.js, Supabase/PostgreSQL",
-      "Open-source alternative to 6sense and Clearbit Reveal"
+      "Open-source alternative to Pocus and Common Room"
     ],
     "cons": [
       "Early stage — small community",

--- a/data/tools.json
+++ b/data/tools.json
@@ -21942,5 +21942,27 @@
     "language": "TypeScript",
     "license": "AGPL-3.0",
     "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=customermates.com"
+  },
+  {
+    "slug": "beton-inspector",
+    "name": "Beton Inspector",
+    "category": "CRM",
+    "is_open_source": true,
+    "github_repo": "getbeton/inspector",
+    "website": "https://getbeton.ai",
+    "description": "Open-source revenue intelligence. Detects buying signals from PostHog product-usage data and your CRM, scores accounts, and routes the warmest leads to sales reps. Self-hostable via Docker.",
+    "pros": [
+      "Scores and routes leads from real product-usage signals (PostHog) + CRM",
+      "Self-hostable via Docker, billing optional",
+      "Modern stack: TypeScript, Next.js, Supabase/PostgreSQL",
+      "Open-source alternative to 6sense and Clearbit Reveal"
+    ],
+    "cons": [
+      "Early stage — small community",
+      "Requires PostHog and a supported CRM to be useful"
+    ],
+    "language": "TypeScript",
+    "license": "AGPL-3.0",
+    "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=getbeton.ai"
   }
 ]


### PR DESCRIPTION
Adds [Beton Inspector](https://github.com/getbeton/inspector) to `data/tools.json` under **CRM** as an open-source tool.

- **Repo:** getbeton/inspector (TypeScript, AGPL-3.0)
- **What it is:** Open-source revenue intelligence — detects buying signals from PostHog product-usage data + CRM, scores accounts, routes the warmest leads to sales reps. Self-hostable via Docker.
- **Open-source alternative to:** Pocus, Common Room

**Criteria check:** actively maintained (recent commits), real-world usage (live SaaS at getbeton.ai + PostHog/Stripe/Attio integrations), self-hostable, FOSS license (AGPL-3.0). Entry follows the existing OSS schema (matches `customermates`).