### PR TITLE
Add Chimely

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -267,6 +267,17 @@
     }
   },
   {
+    "slug": "chimely",
+    "name": "Chimely",
+    "category": "Communication",
+    "is_open_source": true,
+    "github_repo": "dodopayments/chimely",
+    "website": "https://chimely.dev",
+    "description": "Open-source, self-hostable in-app notification inbox infrastructure (Rust + Postgres + Redis) with a drop-in <Inbox /> React component. Self-hosted alternative to Knock, Courier, MagicBell, and Novu.",
+    "language": "Rust",
+    "license": "AGPL-3.0"
+  },
+  {
     "slug": "jira",
     "name": "Jira",
     "category": "Project Management",


### PR DESCRIPTION
Adds Chimely to the tool database. Chimely is an open-source, self-hostable in-app notification inbox infrastructure (Rust + Postgres + Redis) with a drop-in `<Inbox />` React component. Self-hosted alternative to Knock, Courier, MagicBell, and Novu. Repo: https://github.com/dodopayments/chimely  Website: https://chimely.dev  License: AGPL-3.0. Follows the tools.json schema and CRITERIA.