### PR TITLE
Add Orkas to AI Interfaces

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3471,6 +3471,33 @@
     }
   },
   {
+    "slug": "orkas",
+    "name": "Orkas",
+    "category": "AI Interfaces",
+    "is_open_source": true,
+    "github_repo": "Orkas-AI/Orkas",
+    "website": "https://orkas.ai/?source=gh_altstack",
+    "description": "Open-source, local-first desktop AI workforce coordinated by a Commander through one chat.",
+    "pros": [
+      "Multi-agent orchestration through one conversation",
+      "Local-first desktop workspace",
+      "MIT-licensed open source"
+    ],
+    "cons": [
+      "Remote model providers require network access"
+    ],
+    "stars": 725,
+    "language": "TypeScript",
+    "license": "MIT License",
+    "tags": [
+      "AI",
+      "Desktop",
+      "Multi-Agent"
+    ],
+    "hosting_type": "self-hosted",
+    "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=orkas.ai"
+  },
+  {
     "slug": "lm-studio",
     "name": "LM Studio",
     "category": "AI Runners",


### PR DESCRIPTION
## Summary

- Add Orkas to the AI Interfaces category.
- Include its MIT license, TypeScript stack, local-first desktop model, and multi-agent focus.
- Link the project site and source repository.

## Fit

Orkas is an open-source, local-first desktop AI workforce. A Commander coordinates specialist agents in parallel or sequence through one chat. The repository is actively maintained, MIT-licensed, and the desktop client runs on user-owned hardware.

## Verification

- `jq empty data/tools.json`
- Confirmed a single `orkas` slug.
- Checked current GitHub metadata immediately before submission.
