### PR TITLE
Add Atomic Agent as a GitHub Copilot alternative

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3251,7 +3251,8 @@
     "description": "AI pair programmer by GitHub/OpenAI. Integrates into VS Code and JetBrains.",
     "alternatives": [
       "continue-dev",
-      "tabby"
+      "tabby",
+      "atomic-agent"
     ],
     "tags": [
       "AI",
@@ -3353,6 +3354,39 @@
       "agent": "sentinel",
       "timestamp": "2026-03-30T15:26:16.816Z"
     }
+  },
+  {
+    "slug": "atomic-agent",
+    "name": "Atomic Agent",
+    "category": "AI Coding",
+    "is_open_source": true,
+    "github_repo": "AtomicBot-ai/atomic-agent",
+    "website": "https://atomicagent.io",
+    "description": "Local-first CLI and TUI coding agent. Runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. Ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system.",
+    "pros": [
+      "Runs open-weight models entirely on your machine, no account or API key required",
+      "56 built-in tools for browser, filesystem, git, memory, and vision work",
+      "Supports MCP, so external tool servers plug straight in",
+      "Five-layer local memory keeps context across sessions",
+      "Single-command install on macOS, Linux, and Windows"
+    ],
+    "cons": [
+      "Developer preview: APIs, commands, config, and behavior are still moving",
+      "Terminal only, there is no web UI",
+      "Quality depends on the local model and the hardware you run it on"
+    ],
+    "stars": 2024,
+    "language": "TypeScript",
+    "license": "MIT License",
+    "tags": [
+      "AI",
+      "Coding",
+      "CLI",
+      "Local"
+    ],
+    "hardware_req": "8GB+ RAM",
+    "hosting_type": "self-hosted",
+    "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=atomicagent.io"
   },
   {
     "slug": "ollama",


### PR DESCRIPTION
### What does this PR do?

Hi! I'm the CPO of Atomic Agent, and thanks for this great list. Our team would be thrilled if you added us.

This PR adds one new open-source alternative to `data/tools.json`: **Atomic Agent**, listed under the existing `github-copilot` parent in the **AI Coding** category, alongside Continue and TabbyML.

Atomic Agent is a local-first CLI and TUI coding agent. It runs open-weight models entirely on your machine through a `llama.cpp` fork, and needs no account and no API key to install or run. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP for external tool servers, and has a five-layer local memory system that carries context across sessions. Install is one command:

```
curl -fsSL https://atomicagent.io/install | sh
```

Links: [site](https://atomicagent.io) - [docs](https://atomicagent.io/docs) - [GitHub](https://github.com/AtomicBot-ai/atomic-agent) - [Discord](https://discord.gg/Us7qXtDGw) - [X](https://x.com/atomicagent_io)

**Two notes I want to be upfront about, so you can judge the fit yourselves:**

1. **Maturity.** Our README carries an official notice: "Developer preview. APIs, commands, config, and behavior are still moving." The schema has no maturity field, so I put this as the first entry in `cons` rather than leaving it out. We are not claiming production-readiness.

2. **Shape of the tool vs `CRITERIA.md` section 3.** We are a desktop CLI and TUI, so there is no web UI and no Docker image, and the entry therefore has no `deployment` block. Docker is "strongly preferred but not mandatory" in your criteria, and the underlying requirement, "must be deployable on user-owned infrastructure", is met in the strongest form: the model and the whole control loop run on the user's own machine, with no vendor service to phone home to. This matches how you already list Jan ("Native app (no Docker)") and GPT4All (`"deployment": null`), so I followed that precedent. Happy to be told this is the wrong call.

Against the rest of `CRITERIA.md`: MIT license, active (commits this week), ~2k GitHub stars plus an active Discord, and it genuinely replaces the core Copilot workflow rather than just resembling it.

One disambiguation worth flagging: there is a separate, larger project called `BrainBlend-AI/atomic-agents` (~6.2k stars) with a confusingly similar name. It is unrelated to us. Ours is `AtomicBot-ai/atomic-agent`, singular, from the AtomicBot organization. It does not currently appear in `tools.json`, but if you ever add it, the two will need distinct slugs.

Changes are limited to one tool, per the "keep PRs small" guidance: the new entry, plus adding our slug to the `alternatives` array on `github-copilot`.

### Related Issues

None, this is a new tool submission rather than a fix for a filed issue.

### Checklist

- [x] I've read the `CONTRIBUTING.md` guide.
- [x] If this adds a new tool, it includes the required schema fields, notably `id`, `name`, `type`, `url`, `open_source_url`.
- [ ] If this updates docs, the changes are written in MDX to match existing docs in `docs/app/deploy/`. (n/a, no docs changed)
- [x] This maintains a neutral, fact-based tone when making pros/cons edits.

On the schema checkbox: the field names in the template (`id`, `type`, `url`, `open_source_url`) do not match the shape actually used in `data/tools.json`, so I followed the live file instead and mirrored the key set of the neighbouring `tabby` and `continue-dev` entries: `slug`, `name`, `category`, `is_open_source`, `github_repo`, `website`, `description`, `pros`, `cons`, `stars`, `language`, `license`, `tags`, `hardware_req`, `hosting_type`, `logo_url`. I left out `deployment` (no Docker config), `referral_url` (that is yours to set) and `sentinel_verdict` (bot-generated). Let me know if you would like the template's field names used instead.

I ran your `validate-data.yml` check locally (`jq empty` over every file in `data/`) and all files pass. I also confirmed every slug in the file is still unique and that the new `alternatives` reference resolves.

Happy to adjust wording, category, pros/cons, or drop the entry entirely if you feel it is not the right fit. Thanks for maintaining this.
