### PR TITLE
feat(data): add DAC as an open-source Tableau alternative

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -1251,7 +1251,8 @@
     "description": "Powerful data visualization and business intelligence platform.",
     "alternatives": [
       "metabase",
-      "superset"
+      "superset",
+      "dac"
     ],
     "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=tableau.com",
     "pros": [
@@ -1331,6 +1332,30 @@
       "timestamp": "2026-03-30T15:26:16.816Z"
     },
     "_request_heal": "missing_infrastructure"
+  },
+  {
+    "slug": "dac",
+    "name": "DAC",
+    "category": "Analytics",
+    "is_open_source": true,
+    "github_repo": "bruin-data/dac",
+    "stars": 728,
+    "website": "https://getbruin.com/docs/dac/",
+    "description": "Dashboard-as-code tool that defines dashboards in YAML and TSX, with a built-in semantic layer.",
+    "pros": [
+      "Dashboards live in git and are reviewed like code",
+      "Semantic layer defines metrics once and reuses them",
+      "Single Go binary, no external services required",
+      "Connects to Postgres, MySQL, Snowflake, BigQuery, Redshift and Databricks"
+    ],
+    "cons": [
+      "Requires writing YAML or TSX instead of a drag-and-drop editor",
+      "Younger project with a smaller ecosystem than Metabase or Superset"
+    ],
+    "last_commit": "2026-08-19T14:02:46Z",
+    "language": "Go",
+    "license": "AGPLv3",
+    "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=getbruin.com"
   },
   {
     "slug": "auth0",


### PR DESCRIPTION
Adds [DAC](https://github.com/bruin-data/dac) to `data/tools.json` under **Analytics**, and lists it in Tableau's `alternatives` array.

DAC is a dashboard-as-code tool: dashboards are defined in YAML or TSX files, stored in git, and served by a single Go binary. It has a built-in semantic layer for defining metrics and dimensions once and reusing them across widgets, and connects to Postgres, MySQL, Snowflake, BigQuery, Redshift and Databricks.

Against CRITERIA.md:
- **Active maintenance** — commits daily; last commit 2026-08-19; tagged releases.
- **Open source license** — AGPL-3.0.
- **Self-hostability** — single self-contained Go binary you run on your own machine or server; no vendor callback. Docker config not included in this PR.
- **Functional replacement** — replaces the core Tableau workflow (connect to a warehouse, define metrics, build and serve dashboards), for teams that prefer version-controlled definitions over a drag-and-drop editor.
- **Community traction** — 728 GitHub stars.

Scope: one tool, one category, plus the single `alternatives` reference. I did not touch the generated `tools-min.json` / `tools_expanded*.json` files — let me know if you want those regenerated in this PR. `data/tools.json` still parses as valid JSON (146 entries).

Disclosure: I work on the team that builds DAC.