### PR TITLE
Add Posnic to the tool directory

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -1752,6 +1752,38 @@
     }
   },
   {
+    "slug": "posnic",
+    "name": "Posnic",
+    "category": "E-commerce",
+    "is_open_source": true,
+    "github_repo": "Posnic/POS",
+    "stars": 3,
+    "website": "https://posnic.io/",
+    "description": "Free offline-first open source POS and billing software for retail shops and restaurants, with local checkout and online/offline workflows.",
+    "tags": [
+      "POS",
+      "Billing Software",
+      "Offline POS",
+      "Online/Offline POS",
+      "retail",
+      "restaurant",
+      "inventory"
+    ],
+    "pros": [
+      "Desktop and self-hosted server options keep checkout data on shop-controlled infrastructure",
+      "Retail and restaurant billing workflows include inventory, tax invoices, returns, held bills, and kitchen order tickets",
+      "Windows, macOS, and Linux packages are published with a stable v1.6.1 release"
+    ],
+    "cons": [
+      "Young open-source project with a small public GitHub community",
+      "Release packages bundle separately licensed components that need package-level license review"
+    ],
+    "last_commit": "2026-09-02T14:07:45Z",
+    "language": "JavaScript",
+    "license": "AGPL-3.0",
+    "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=posnic.io"
+  },
+  {
     "slug": "docusign",
     "name": "DocuSign",
     "category": "Legal",

--- a/data/tools.json
+++ b/data/tools.json
@@ -1778,7 +1778,7 @@
       "Young open-source project with a small public GitHub community",
       "Release packages bundle separately licensed components that need package-level license review"
     ],
-    "last_commit": "2026-09-02T14:07:45Z",
+    "last_commit": "2026-09-08T12:24:11Z",
     "language": "JavaScript",
     "license": "AGPL-3.0",
     "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=posnic.io"

--- a/data/tools.json
+++ b/data/tools.json
@@ -1758,7 +1758,7 @@
     "is_open_source": true,
     "github_repo": "Posnic/POS",
     "stars": 3,
-    "website": "https://posnic.io/",
+    "website": "https://www.posnic.com/",
     "description": "Free offline-first open source POS and billing software for retail shops and restaurants, with local checkout and online/offline workflows.",
     "tags": [
       "POS",
@@ -1781,7 +1781,7 @@
     "last_commit": "2026-09-08T12:24:11Z",
     "language": "JavaScript",
     "license": "AGPL-3.0",
-    "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=posnic.io"
+    "logo_url": "https://www.google.com/s2/favicons?sz=128&domain=www.posnic.com"
   },
   {
     "slug": "docusign",


### PR DESCRIPTION
### What does this PR do?

Adds Posnic to `data/tools.json` as an open-source POS and billing software entry in the E-commerce category.

Posnic links:
- Website: https://www.posnic.com/
- Source: https://github.com/Posnic/POS

The entry keeps the tone factual and includes a caveat that Posnic is a young open-source project with a small public GitHub community.

### Related Issues

N/A

### Validation

- Parsed `data/tools.json` with Node and confirmed the `posnic` entry is present.
- Validated every JSON file under `data/` with `jq empty`.
- Ran `git diff --check`.
- Ran `npm --prefix docs ci`.
- Ran `npm --prefix docs run build`; Next.js build and Pagefind indexing completed successfully. Generated Pagefind artifacts were not committed so the PR stays focused on the source data.

Note: `npm ci` reports existing upstream audit warnings and an allow-scripts warning for `sharp`; no dependency changes are included in this PR.

### Checklist

- [x] I've read the `CONTRIBUTING.md` guide.
- [x] This adds a new tool entry in `data/tools.json` using the existing schema style.
- [x] This maintains a neutral, fact-based tone when making pros/cons edits.

I am affiliated with Posnic and prepared this contribution with automation assistance.

