### PR TITLE
data: add Jasper with AltoRank as its open-source alternative

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2780,6 +2780,72 @@
     }
   },
   {
+    "slug": "jasper",
+    "name": "Jasper",
+    "category": "Marketing",
+    "is_open_source": false,
+    "pricing_model": "Paid",
+    "website": "https://www.jasper.ai",
+    "description": "AI content platform for marketing teams, with brand voice controls and SEO templates.",
+    "alternatives": [
+      "altorank"
+    ],
+    "tags": [
+      "AI",
+      "Content",
+      "Marketing",
+      "SEO"
+    ],
+    "logo_url": "https://unavatar.io/jasper.ai?fallback=https://www.google.com/s2/favicons?sz=128%26domain=jasper.ai",
+    "avg_monthly_cost": 69,
+    "pros": [
+      "Mature brand voice and style controls",
+      "Large template library for marketing copy",
+      "Team collaboration and brand guidelines built in"
+    ],
+    "cons": [
+      "No self-hosting; content and brand data live with the vendor",
+      "Priced per seat, so team costs scale quickly",
+      "Writing-first: no keyword research, rank tracking or CMS publishing"
+    ],
+    "has_deployable_alternative": true
+  },
+  {
+    "slug": "altorank",
+    "name": "AltoRank",
+    "category": "Marketing",
+    "is_open_source": true,
+    "github_repo": "AltoRank/altorank",
+    "stars": 1,
+    "website": "https://altorank.co",
+    "description": "AI SEO content engine: keyword research, domain audit, drafting with scoring and fact-checking, rank tracking, AI-answer visibility, and publishing to 13 destinations across 10 CMS platforms. A person approves every article; no API or MCP call can publish a draft.",
+    "pros": [
+      "Whole product is open source under AGPL-3.0, with no feature-gated tier",
+      "Runs the full loop from keyword to published article, not one step of it",
+      "Self-hostable against your own Supabase and your own API keys",
+      "Ships an MCP server, so an AI assistant can drive it"
+    ],
+    "cons": [
+      "Pre-launch: no paying customers and no case studies yet",
+      "Needs your own Anthropic and DataForSEO keys to be useful",
+      "No packaged CLI yet"
+    ],
+    "last_commit": "2026-09-07T00:00:00Z",
+    "language": "TypeScript",
+    "license": "GNU Affero General Public License v3.0",
+    "tags": [
+      "SEO",
+      "AI",
+      "Content",
+      "Marketing",
+      "GEO"
+    ],
+    "logo_url": "https://unavatar.io/altorank.co?fallback=https://www.google.com/s2/favicons?sz=128%26domain=altorank.co",
+    "alternatives": [],
+    "hosting_type": "self-hosted",
+    "avg_monthly_cost": 0
+  },
+  {
     "slug": "dokku",
     "name": "Dokku",
     "category": "DevOps",


### PR DESCRIPTION
## What

Adds two entries to `data/tools.json`:

- **Jasper** — proprietary parent, `Marketing` category, Pro at $69/mo per seat (verified on jasper.ai/pricing today, annual $59)
- **AltoRank** — AGPL-3.0 alternative, listed under Jasper's `alternatives`

## Why a new parent

`Marketing` currently covers email (Mailchimp), social (Hootsuite) and CDP (Segment), but there is no AI-content or SEO parent anywhere in the dataset, so there was no existing tool to file this under. Jasper is the most recognised proprietary product in that space.

## Where it stands against CRITERIA.md

Rather than let you discover these in review:

- **✅ Active maintenance** — commits daily, first tagged release v0.1.0
- **✅ Open source licence** — AGPL-3.0, the whole product, no `ee/` directory or feature-gated tier
- **✅ Self-hostable** — `docker/compose.yml`, runs against your own Supabase and your own API keys
- **⚠️ Functional replacement — partial.** AltoRank covers what Jasper is used for in SEO content (research, drafting in a brand voice, publishing) and adds keyword research, rank tracking and CMS publishing, which Jasper does not do. It is *not* a general marketing-copy tool: no ad copy, no social templates. If you would rather file it under a Surfer SEO or Outrank parent, I will happily redo it — Jasper is the better-known name, but Surfer is the closer functional match.
- **❌ Minimum community traction — it fails this today.** 1 star, pre-launch, no paying customers, no case studies. The README says so plainly. I have listed it honestly rather than dressing it up; if that puts it below your bar, closing this is the right call and I will resubmit when there is real usage to point at.

I did not add a `deployment` block, since you test every Docker config and I have not submitted one.

Disclosure: I am the author of AltoRank. The Jasper entry is written to be fair to Jasper — its cons are structural (no self-hosting, per-seat pricing, writing-first scope), not swipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)